### PR TITLE
base: Reduce number of layers, add missing bzip2

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,23 +1,6 @@
 FROM debian:stretch-slim
 MAINTAINER Emmanuele Bassi <ebassi@gmail.com>
 
-RUN echo "deb-src http://httpredir.debian.org/debian stretch main" >> /etc/apt/sources.list
-
-RUN apt-get update -qq && \
-    apt-get install -qq -y --no-install-recommends \
-        flatpak \
-        git-core \
-        locales \
-        make && \
-    rm -rf /usr/share/doc/* /usr/share/man/*
-
-RUN locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
-
-ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
-
 COPY flatpak-build.sh /root
-RUN chmod +x /root/flatpak-build.sh
-
-RUN /root/flatpak-build.sh
-
-RUN flatpak remote-add --if-not-exists gnome https://sdk.gnome.org/gnome.flatpakrepo
+RUN chmod +x /root/flatpak-build.sh && /root/flatpak-build.sh
+ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8

--- a/base/flatpak-build.sh
+++ b/base/flatpak-build.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/bin/bash -eu
+
+echo "deb-src http://httpredir.debian.org/debian stretch main" >> /etc/apt/sources.list
+
+apt-get update -qq
+apt-get install -qq -y --no-install-recommends \
+        flatpak \
+        git-core \
+        locales \
+        make \
+        aptitude \
+        bzip2
+
+locale-gen C.UTF-8
+/usr/sbin/update-locale LANG=C.UTF-8
 
 apt-get build-dep -qq -y --no-install-recommends \
         ostree \
@@ -76,11 +90,18 @@ apt-get remove -y --purge \
         python3.5-minimal \
         sgml-base \
         sgml-data \
+        systemd \
         xml-core \
         xmlto \
         xorg-sgml-doctools \
         xsltproc
 
-apt autoremove -y
+aptitude purge -y $(aptitude search '~c' | awk '{ print $2 }')
+apt-get remove --purge -y aptitude
+apt-get autoremove -y
 
-rm -rf /usr/share/doc/* /usr/share/man/*
+rm -rf /usr/share/doc/* \
+       /usr/share/man/* \
+       /var/lib/apt/lists/*
+
+flatpak remote-add --if-not-exists gnome https://sdk.gnome.org/gnome.flatpakrepo


### PR DESCRIPTION
This will also remove additional files that were taking up unnecessary space in the resulting image.

It's now down to 268MB, from 322MB, and removes five layers.